### PR TITLE
Shallow copy chunk_result to fix unittest

### DIFF
--- a/mars/executor.py
+++ b/mars/executor.py
@@ -611,7 +611,7 @@ class Executor(object):
         res = graph_execution.execute(retval)
         self._mock_max_memory = max(self._mock_max_memory, graph_execution._mock_max_memory)
         if mock:
-            self._chunk_result.clear()
+            chunk_result.clear()
         return res
 
     @kernel_mode

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -627,9 +627,9 @@ class Executor(object):
         chunk_result = self._chunk_result.copy()
         graph = tileable.build_graph(cls=DirectedGraph, tiled=True, compose=compose)
         ret = self.execute_graph(graph, [c.key for c in tileable.chunks],
-                                  n_parallel=n_parallel or n_thread,
-                                  print_progress=print_progress, mock=mock,
-                                  chunk_result=chunk_result)
+                                 n_parallel=n_parallel or n_thread,
+                                 print_progress=print_progress, mock=mock,
+                                 chunk_result=chunk_result)
         self._chunk_result.update(chunk_result)
         return ret
 

--- a/mars/executor.py
+++ b/mars/executor.py
@@ -623,11 +623,15 @@ class Executor(object):
             if len(tileable.chunks) > 1:
                 tileable = tileable.op.concat_tileable_chunks(tileable)
 
+        # shallow copy
+        chunk_result = self._chunk_result.copy()
         graph = tileable.build_graph(cls=DirectedGraph, tiled=True, compose=compose)
-
-        return self.execute_graph(graph, [c.key for c in tileable.chunks],
+        ret = self.execute_graph(graph, [c.key for c in tileable.chunks],
                                   n_parallel=n_parallel or n_thread,
-                                  print_progress=print_progress, mock=mock)
+                                  print_progress=print_progress, mock=mock,
+                                  chunk_result=chunk_result)
+        self._chunk_result.update(chunk_result)
+        return ret
 
     execute_tensor = execute_tileable
     execute_dataframe = execute_tileable

--- a/mars/tests/test_prefetch.py
+++ b/mars/tests/test_prefetch.py
@@ -60,6 +60,13 @@ class MockStorage(object):
     def __delitem__(self, key):
         pass
 
+    def copy(self):
+        return MockStorage()
+
+    def update(self, other):
+        self._data1.update(other._data1)
+        self._data2.update(other._data2)
+
 
 class Test(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/mars-project/mars/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The `test_reduction.Test.testNanReduction` will fail occasionally, I found that two execution will cause inconsistent change to `chunk_result`, thus I will do shallow copy each time `execute_tileable`, then merge back into `Executor.chunk_result`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

NA
